### PR TITLE
Fix bug creating PostgresQL table, Add Errata, code clean up.

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -1,0 +1,17 @@
+# Errata for _gorestful_
+
+Corrections for the book [_Building RESTful Web Services with Go_](). The pages listed are for the released book itself, not for any preprints or other forms of the articles.
+
+### First Printing, December 2017
+
+## Page 162, Installing the PostgrSQL database.
+#### sudo sh -c 'echo “deb ht<span>tp://apt.postgresql.org/pub/repos/apt/ \`lsb_release -cs\`-pgdg main” >> /etc/apt/sources.list.d/pgdg.list'
+
+For `Ubuntu 18.04LTS` open the file `/etc/apt/sources.list.d/pgdg.list` as [root]() and if the first and
+ last characters are double quotes, remove them to overcome error:
+
+#### E: Type ‘“deb’ is not known on line 1 in source list /etc/apt/sources.list.d/pgdg.list
+
+produced when doing:
+
+#### sudo apt-get update

--- a/chapter7/basicexample/models/models.go
+++ b/chapter7/basicexample/models/models.go
@@ -14,7 +14,7 @@ func InitDB() (*sql.DB, error) {
                 return nil, err
         } else {
                 // Create model for our URL service
-                stmt, err := db.Prepare("CREATE TABLE WEB_URL(ID SERIAL PRIMARY KEY, URL TEXT NOT NULL);")
+                stmt, err := db.Prepare("CREATE TABLE IF NOT EXISTS WEB_URL(ID SERIAL PRIMARY KEY, URL TEXT NOT NULL);")
                 if err != nil {
                         log.Println(err)
                         return nil, err

--- a/chapter7/jsonstore/main.go
+++ b/chapter7/jsonstore/main.go
@@ -62,7 +62,7 @@ func (driver *DBClient) PostUser(w http.ResponseWriter, r *http.Request) {
 	user.Data = string(postBody)
 	driver.db.Save(&user)
 	responseMap := map[string]interface{}{"id": user.ID}
-	var err string = ""
+	var err string = "" // !!! a comment here to explain what this is about would help
 	if err != "" {
 		w.Write([]byte("yes"))
 	} else {
@@ -78,9 +78,6 @@ func main() {
 		panic(err)
 	}
 	dbclient := &DBClient{db: db}
-	if err != nil {
-		panic(err)
-	}
 	defer db.Close()
 	// Create a new router
 	r := mux.NewRouter()

--- a/chapter7/urlshortener/main.go
+++ b/chapter7/urlshortener/main.go
@@ -67,9 +67,6 @@ func main() {
 		panic(err)
 	}
 	dbclient := &DBClient{db: db}
-	if err != nil {
-		panic(err)
-	}
 	defer db.Close()
 	// Create a new router
 	r := mux.NewRouter()

--- a/chapter7/urlshortener/models/models.go
+++ b/chapter7/urlshortener/models/models.go
@@ -13,7 +13,7 @@ func InitDB() (*sql.DB, error) {
 		return nil, err
 	} else {
 		// Create model for our URL service
-		stmt, err := db.Prepare("CREATE TABLE WEB_URL(ID SERIAL PRIMARY KEY, URL TEXT NOT NULL);")
+		stmt, err := db.Prepare("CREATE TABLE IF NOT EXISTS WEB_URL(ID SERIAL PRIMARY KEY, URL TEXT NOT NULL);")
 		if err != nil {
 			log.Println(err)
 			return nil, err


### PR DESCRIPTION
Hello Naren,
I am continuing working through the book and found a few more issues ...

Fix application failing if trying to create a table that already exists.
Add Errata for page 162 and Ubuntu PostgresQL setup.
Remove a duplicated and redundant error check.

I ran chapter 7's basicexample and that was OK, but because it created the table in the postgresQL database, when i then cam to run the urlshortener it threw a panic from the database driver when it tried to create a table that already existed ... so i have modified both of the InitDB's in the botjh projects.

Kind Regards,

Rhys