### PR TITLE
Fix syntax for struct tag key in Chapter3 jsonRPCServer

### DIFF
--- a/chapter3/jsonRPCServer.go
+++ b/chapter3/jsonRPCServer.go
@@ -17,9 +17,9 @@ type Args struct {
 }
 
 type Book struct {
-	Id     string `"json:id,omitempty"`
-	Name   string `"json:name,omitempty"`
-	Author string `"json:author,omitempty"`
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Author string `json:"author,omitempty"`
 }
 
 type JSONServer struct{}


### PR DESCRIPTION
The correct syntax for struct tags is `key:"value"`, otherwise the editor will show below warning:
struct field tag `"json:author,omitempty"` not compatible with reflect.StructTag.Get: bad syntax for struct tag key structtag